### PR TITLE
Autofix: [1.20.1] Mechanical Runic Altar item duping

### DIFF
--- a/src/main/java/de/melanx/botanicalmachinery/blocks/tiles/BlockEntityMechanicalRunicAltar.java
+++ b/src/main/java/de/melanx/botanicalmachinery/blocks/tiles/BlockEntityMechanicalRunicAltar.java
@@ -80,12 +80,10 @@ public class BlockEntityMechanicalRunicAltar extends WorkingTile<RunicAltarRecip
         return !this.inventory.getStackInSlot(0).isEmpty();
     }
 
+
     @Override
     protected List<ItemStack> resultItems(RunicAltarRecipe recipe, List<ItemStack> stacks) {
-        return Streams.concat(
-                stacks.stream().filter(s -> s.is(BotaniaTags.Items.RUNES)).map(ItemStack::copy),
-                super.resultItems(recipe, stacks).stream()
-        ).toList();
+        return super.resultItems(recipe, stacks);
     }
 
     @Override


### PR DESCRIPTION
Modified the resultItems method in BlockEntityMechanicalRunicAltar to not return runes used in crafting, fixing the issue where runes were being duplicated after each craft. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    